### PR TITLE
Feature/cancelling account histories migration

### DIFF
--- a/html/mycakeapp/config/Migrations/20201201070859_CreateCancellingAccountHistories.php
+++ b/html/mycakeapp/config/Migrations/20201201070859_CreateCancellingAccountHistories.php
@@ -1,0 +1,32 @@
+<?php
+use Migrations\AbstractMigration;
+
+class CreateCancellingAccountHistories extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('cancelling_account_histories');
+        $table->addColumn('user_id', 'integer', [
+            'default' => null,
+            'limit' => 11,
+            'null' => false,
+        ]);
+        $table->addColumn('cancelling_category_id', 'integer', [
+            'default' => null,
+            'limit' => 11,
+            'null' => false,
+        ]);
+        $table->addColumn('cancelled', 'datetime', [
+            'default' => null,
+            'null' => false,
+        ]);
+        $table->create();
+    }
+}

--- a/html/mycakeapp/src/Controller/CancellingAccountHistoriesController.php
+++ b/html/mycakeapp/src/Controller/CancellingAccountHistoriesController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Controller;
 
 use App\Controller\AppController;
@@ -20,7 +21,7 @@ class CancellingAccountHistoriesController extends AppController
     public function index()
     {
         $this->paginate = [
-            'contain' => ['Users', 'CancellingCategories'],
+            'contain' => ['Users', 'cancelling_account_categories'],
         ];
         $cancellingAccountHistories = $this->paginate($this->CancellingAccountHistories);
 
@@ -37,7 +38,7 @@ class CancellingAccountHistoriesController extends AppController
     public function view($id = null)
     {
         $cancellingAccountHistory = $this->CancellingAccountHistories->get($id, [
-            'contain' => ['Users', 'CancellingCategories'],
+            'contain' => ['Users', 'cancelling_account_categories'],
         ]);
 
         $this->set('cancellingAccountHistory', $cancellingAccountHistory);
@@ -61,7 +62,7 @@ class CancellingAccountHistoriesController extends AppController
             $this->Flash->error(__('The cancelling account history could not be saved. Please, try again.'));
         }
         $users = $this->CancellingAccountHistories->Users->find('list', ['limit' => 200]);
-        $cancellingCategories = $this->CancellingAccountHistories->CancellingCategories->find('list', ['limit' => 200]);
+        $cancellingCategories = $this->CancellingAccountHistories->cancelling_account_categories->find('list', ['limit' => 200]);
         $this->set(compact('cancellingAccountHistory', 'users', 'cancellingCategories'));
     }
 
@@ -87,7 +88,7 @@ class CancellingAccountHistoriesController extends AppController
             $this->Flash->error(__('The cancelling account history could not be saved. Please, try again.'));
         }
         $users = $this->CancellingAccountHistories->Users->find('list', ['limit' => 200]);
-        $cancellingCategories = $this->CancellingAccountHistories->CancellingCategories->find('list', ['limit' => 200]);
+        $cancellingCategories = $this->CancellingAccountHistories->cancelling_account_categories->find('list', ['limit' => 200]);
         $this->set(compact('cancellingAccountHistory', 'users', 'cancellingCategories'));
     }
 

--- a/html/mycakeapp/src/Controller/CancellingAccountHistoriesController.php
+++ b/html/mycakeapp/src/Controller/CancellingAccountHistoriesController.php
@@ -1,0 +1,113 @@
+<?php
+namespace App\Controller;
+
+use App\Controller\AppController;
+
+/**
+ * CancellingAccountHistories Controller
+ *
+ * @property \App\Model\Table\CancellingAccountHistoriesTable $CancellingAccountHistories
+ *
+ * @method \App\Model\Entity\CancellingAccountHistory[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
+ */
+class CancellingAccountHistoriesController extends AppController
+{
+    /**
+     * Index method
+     *
+     * @return \Cake\Http\Response|null
+     */
+    public function index()
+    {
+        $this->paginate = [
+            'contain' => ['Users', 'CancellingCategories'],
+        ];
+        $cancellingAccountHistories = $this->paginate($this->CancellingAccountHistories);
+
+        $this->set(compact('cancellingAccountHistories'));
+    }
+
+    /**
+     * View method
+     *
+     * @param string|null $id Cancelling Account History id.
+     * @return \Cake\Http\Response|null
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     */
+    public function view($id = null)
+    {
+        $cancellingAccountHistory = $this->CancellingAccountHistories->get($id, [
+            'contain' => ['Users', 'CancellingCategories'],
+        ]);
+
+        $this->set('cancellingAccountHistory', $cancellingAccountHistory);
+    }
+
+    /**
+     * Add method
+     *
+     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
+     */
+    public function add()
+    {
+        $cancellingAccountHistory = $this->CancellingAccountHistories->newEntity();
+        if ($this->request->is('post')) {
+            $cancellingAccountHistory = $this->CancellingAccountHistories->patchEntity($cancellingAccountHistory, $this->request->getData());
+            if ($this->CancellingAccountHistories->save($cancellingAccountHistory)) {
+                $this->Flash->success(__('The cancelling account history has been saved.'));
+
+                return $this->redirect(['action' => 'index']);
+            }
+            $this->Flash->error(__('The cancelling account history could not be saved. Please, try again.'));
+        }
+        $users = $this->CancellingAccountHistories->Users->find('list', ['limit' => 200]);
+        $cancellingCategories = $this->CancellingAccountHistories->CancellingCategories->find('list', ['limit' => 200]);
+        $this->set(compact('cancellingAccountHistory', 'users', 'cancellingCategories'));
+    }
+
+    /**
+     * Edit method
+     *
+     * @param string|null $id Cancelling Account History id.
+     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     */
+    public function edit($id = null)
+    {
+        $cancellingAccountHistory = $this->CancellingAccountHistories->get($id, [
+            'contain' => [],
+        ]);
+        if ($this->request->is(['patch', 'post', 'put'])) {
+            $cancellingAccountHistory = $this->CancellingAccountHistories->patchEntity($cancellingAccountHistory, $this->request->getData());
+            if ($this->CancellingAccountHistories->save($cancellingAccountHistory)) {
+                $this->Flash->success(__('The cancelling account history has been saved.'));
+
+                return $this->redirect(['action' => 'index']);
+            }
+            $this->Flash->error(__('The cancelling account history could not be saved. Please, try again.'));
+        }
+        $users = $this->CancellingAccountHistories->Users->find('list', ['limit' => 200]);
+        $cancellingCategories = $this->CancellingAccountHistories->CancellingCategories->find('list', ['limit' => 200]);
+        $this->set(compact('cancellingAccountHistory', 'users', 'cancellingCategories'));
+    }
+
+    /**
+     * Delete method
+     *
+     * @param string|null $id Cancelling Account History id.
+     * @return \Cake\Http\Response|null Redirects to index.
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     */
+    public function delete($id = null)
+    {
+        $this->request->allowMethod(['post', 'delete']);
+        $cancellingAccountHistory = $this->CancellingAccountHistories->get($id);
+        if ($this->CancellingAccountHistories->delete($cancellingAccountHistory)) {
+            $this->Flash->success(__('The cancelling account history has been deleted.'));
+        } else {
+            $this->Flash->error(__('The cancelling account history could not be deleted. Please, try again.'));
+        }
+
+        return $this->redirect(['action' => 'index']);
+    }
+}

--- a/html/mycakeapp/src/Controller/CancellingAccountHistoriesController.php
+++ b/html/mycakeapp/src/Controller/CancellingAccountHistoriesController.php
@@ -21,7 +21,7 @@ class CancellingAccountHistoriesController extends AppController
     public function index()
     {
         $this->paginate = [
-            'contain' => ['Users', 'cancelling_account_categories'],
+            'contain' => ['Users', 'Cancelling_Account_Categories'],
         ];
         $cancellingAccountHistories = $this->paginate($this->CancellingAccountHistories);
 
@@ -38,7 +38,7 @@ class CancellingAccountHistoriesController extends AppController
     public function view($id = null)
     {
         $cancellingAccountHistory = $this->CancellingAccountHistories->get($id, [
-            'contain' => ['Users', 'cancelling_account_categories'],
+            'contain' => ['Users', 'Cancelling_Account_Categories'],
         ]);
 
         $this->set('cancellingAccountHistory', $cancellingAccountHistory);
@@ -62,7 +62,7 @@ class CancellingAccountHistoriesController extends AppController
             $this->Flash->error(__('The cancelling account history could not be saved. Please, try again.'));
         }
         $users = $this->CancellingAccountHistories->Users->find('list', ['limit' => 200]);
-        $cancellingCategories = $this->CancellingAccountHistories->cancelling_account_categories->find('list', ['limit' => 200]);
+        $cancellingCategories = $this->CancellingAccountHistories->Cancelling_Account_Categories->find('list', ['limit' => 200]);
         $this->set(compact('cancellingAccountHistory', 'users', 'cancellingCategories'));
     }
 
@@ -88,7 +88,7 @@ class CancellingAccountHistoriesController extends AppController
             $this->Flash->error(__('The cancelling account history could not be saved. Please, try again.'));
         }
         $users = $this->CancellingAccountHistories->Users->find('list', ['limit' => 200]);
-        $cancellingCategories = $this->CancellingAccountHistories->cancelling_account_categories->find('list', ['limit' => 200]);
+        $cancellingCategories = $this->CancellingAccountHistories->Cancelling_Account_Categories->find('list', ['limit' => 200]);
         $this->set(compact('cancellingAccountHistory', 'users', 'cancellingCategories'));
     }
 

--- a/html/mycakeapp/src/Controller/CancellingAccountHistoriesController.php
+++ b/html/mycakeapp/src/Controller/CancellingAccountHistoriesController.php
@@ -21,7 +21,7 @@ class CancellingAccountHistoriesController extends AppController
     public function index()
     {
         $this->paginate = [
-            'contain' => ['Users', 'Cancelling_Account_Categories'],
+            'contain' => ['Users', 'CancellingAccountCategories'],
         ];
         $cancellingAccountHistories = $this->paginate($this->CancellingAccountHistories);
 
@@ -38,7 +38,7 @@ class CancellingAccountHistoriesController extends AppController
     public function view($id = null)
     {
         $cancellingAccountHistory = $this->CancellingAccountHistories->get($id, [
-            'contain' => ['Users', 'Cancelling_Account_Categories'],
+            'contain' => ['Users', 'CancellingAccountCategories'],
         ]);
 
         $this->set('cancellingAccountHistory', $cancellingAccountHistory);
@@ -62,7 +62,7 @@ class CancellingAccountHistoriesController extends AppController
             $this->Flash->error(__('The cancelling account history could not be saved. Please, try again.'));
         }
         $users = $this->CancellingAccountHistories->Users->find('list', ['limit' => 200]);
-        $cancellingCategories = $this->CancellingAccountHistories->Cancelling_Account_Categories->find('list', ['limit' => 200]);
+        $cancellingCategories = $this->CancellingAccountHistories->CancellingAccountCategories->find('list', ['limit' => 200]);
         $this->set(compact('cancellingAccountHistory', 'users', 'cancellingCategories'));
     }
 
@@ -88,7 +88,7 @@ class CancellingAccountHistoriesController extends AppController
             $this->Flash->error(__('The cancelling account history could not be saved. Please, try again.'));
         }
         $users = $this->CancellingAccountHistories->Users->find('list', ['limit' => 200]);
-        $cancellingCategories = $this->CancellingAccountHistories->Cancelling_Account_Categories->find('list', ['limit' => 200]);
+        $cancellingCategories = $this->CancellingAccountHistories->CancellingAccountCategories->find('list', ['limit' => 200]);
         $this->set(compact('cancellingAccountHistory', 'users', 'cancellingCategories'));
     }
 

--- a/html/mycakeapp/src/Model/Entity/CancellingAccountHistory.php
+++ b/html/mycakeapp/src/Model/Entity/CancellingAccountHistory.php
@@ -1,0 +1,35 @@
+<?php
+namespace App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * CancellingAccountHistory Entity
+ *
+ * @property int $id
+ * @property int $user_id
+ * @property int $cancelling_category_id
+ * @property \Cake\I18n\Time $cancelled
+ *
+ * @property \App\Model\Entity\User $user
+ * @property \App\Model\Entity\CancellingCategory $cancelling_category
+ */
+class CancellingAccountHistory extends Entity
+{
+    /**
+     * Fields that can be mass assigned using newEntity() or patchEntity().
+     *
+     * Note that when '*' is set to true, this allows all unspecified fields to
+     * be mass assigned. For security purposes, it is advised to set '*' to false
+     * (or remove it), and explicitly make individual fields accessible as needed.
+     *
+     * @var array
+     */
+    protected $_accessible = [
+        'user_id' => true,
+        'cancelling_category_id' => true,
+        'cancelled' => true,
+        'user' => true,
+        'cancelling_category' => true,
+    ];
+}

--- a/html/mycakeapp/src/Model/Entity/CancellingAccountHistory.php
+++ b/html/mycakeapp/src/Model/Entity/CancellingAccountHistory.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Model\Entity;
 
 use Cake\ORM\Entity;
@@ -30,6 +31,6 @@ class CancellingAccountHistory extends Entity
         'cancelling_category_id' => true,
         'cancelled' => true,
         'user' => true,
-        'cancelling_category' => true,
+        'cancelling_account_categories' => true,
     ];
 }

--- a/html/mycakeapp/src/Model/Entity/CancellingAccountHistory.php
+++ b/html/mycakeapp/src/Model/Entity/CancellingAccountHistory.php
@@ -31,6 +31,6 @@ class CancellingAccountHistory extends Entity
         'cancelling_category_id' => true,
         'cancelled' => true,
         'user' => true,
-        'cancelling_account_categories' => true,
+        'cancelling_account_category' => true,
     ];
 }

--- a/html/mycakeapp/src/Model/Table/CancellingAccountHistoriesTable.php
+++ b/html/mycakeapp/src/Model/Table/CancellingAccountHistoriesTable.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Model\Table;
 
 use Cake\ORM\Query;
@@ -41,7 +42,7 @@ class CancellingAccountHistoriesTable extends Table
             'foreignKey' => 'user_id',
             'joinType' => 'INNER',
         ]);
-        $this->belongsTo('CancellingCategories', [
+        $this->belongsTo('cancelling_account_categories', [
             'foreignKey' => 'cancelling_category_id',
             'joinType' => 'INNER',
         ]);
@@ -77,7 +78,7 @@ class CancellingAccountHistoriesTable extends Table
     public function buildRules(RulesChecker $rules)
     {
         $rules->add($rules->existsIn(['user_id'], 'Users'));
-        $rules->add($rules->existsIn(['cancelling_category_id'], 'CancellingCategories'));
+        $rules->add($rules->existsIn(['cancelling_category_id'], 'cancelling_account_categories'));
 
         return $rules;
     }

--- a/html/mycakeapp/src/Model/Table/CancellingAccountHistoriesTable.php
+++ b/html/mycakeapp/src/Model/Table/CancellingAccountHistoriesTable.php
@@ -1,0 +1,84 @@
+<?php
+namespace App\Model\Table;
+
+use Cake\ORM\Query;
+use Cake\ORM\RulesChecker;
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+
+/**
+ * CancellingAccountHistories Model
+ *
+ * @property \App\Model\Table\UsersTable&\Cake\ORM\Association\BelongsTo $Users
+ * @property \App\Model\Table\CancellingCategoriesTable&\Cake\ORM\Association\BelongsTo $CancellingCategories
+ *
+ * @method \App\Model\Entity\CancellingAccountHistory get($primaryKey, $options = [])
+ * @method \App\Model\Entity\CancellingAccountHistory newEntity($data = null, array $options = [])
+ * @method \App\Model\Entity\CancellingAccountHistory[] newEntities(array $data, array $options = [])
+ * @method \App\Model\Entity\CancellingAccountHistory|false save(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \App\Model\Entity\CancellingAccountHistory saveOrFail(\Cake\Datasource\EntityInterface $entity, $options = [])
+ * @method \App\Model\Entity\CancellingAccountHistory patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
+ * @method \App\Model\Entity\CancellingAccountHistory[] patchEntities($entities, array $data, array $options = [])
+ * @method \App\Model\Entity\CancellingAccountHistory findOrCreate($search, callable $callback = null, $options = [])
+ */
+class CancellingAccountHistoriesTable extends Table
+{
+    /**
+     * Initialize method
+     *
+     * @param array $config The configuration for the Table.
+     * @return void
+     */
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $this->setTable('cancelling_account_histories');
+        $this->setDisplayField('id');
+        $this->setPrimaryKey('id');
+
+        $this->belongsTo('Users', [
+            'foreignKey' => 'user_id',
+            'joinType' => 'INNER',
+        ]);
+        $this->belongsTo('CancellingCategories', [
+            'foreignKey' => 'cancelling_category_id',
+            'joinType' => 'INNER',
+        ]);
+    }
+
+    /**
+     * Default validation rules.
+     *
+     * @param \Cake\Validation\Validator $validator Validator instance.
+     * @return \Cake\Validation\Validator
+     */
+    public function validationDefault(Validator $validator)
+    {
+        $validator
+            ->integer('id')
+            ->allowEmptyString('id', null, 'create');
+
+        $validator
+            ->dateTime('cancelled')
+            ->requirePresence('cancelled', 'create')
+            ->notEmptyDateTime('cancelled');
+
+        return $validator;
+    }
+
+    /**
+     * Returns a rules checker object that will be used for validating
+     * application integrity.
+     *
+     * @param \Cake\ORM\RulesChecker $rules The rules object to be modified.
+     * @return \Cake\ORM\RulesChecker
+     */
+    public function buildRules(RulesChecker $rules)
+    {
+        $rules->add($rules->existsIn(['user_id'], 'Users'));
+        $rules->add($rules->existsIn(['cancelling_category_id'], 'CancellingCategories'));
+
+        return $rules;
+    }
+}

--- a/html/mycakeapp/src/Model/Table/CancellingAccountHistoriesTable.php
+++ b/html/mycakeapp/src/Model/Table/CancellingAccountHistoriesTable.php
@@ -42,7 +42,7 @@ class CancellingAccountHistoriesTable extends Table
             'foreignKey' => 'user_id',
             'joinType' => 'INNER',
         ]);
-        $this->belongsTo('cancelling_account_categories', [
+        $this->belongsTo('CancellingAccountCategories', [
             'foreignKey' => 'cancelling_category_id',
             'joinType' => 'INNER',
         ]);
@@ -78,7 +78,7 @@ class CancellingAccountHistoriesTable extends Table
     public function buildRules(RulesChecker $rules)
     {
         $rules->add($rules->existsIn(['user_id'], 'Users'));
-        $rules->add($rules->existsIn(['cancelling_category_id'], 'cancelling_account_categories'));
+        $rules->add($rules->existsIn(['cancelling_category_id'], 'CancellingAccountCategories'));
 
         return $rules;
     }

--- a/html/mycakeapp/src/Template/CancellingAccountHistories/add.ctp
+++ b/html/mycakeapp/src/Template/CancellingAccountHistories/add.ctp
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var \App\Model\Entity\CancellingAccountHistory $cancellingAccountHistory
+ */
+?>
+<nav class="large-3 medium-4 columns" id="actions-sidebar">
+    <ul class="side-nav">
+        <li class="heading"><?= __('Actions') ?></li>
+        <li><?= $this->Html->link(__('List Cancelling Account Histories'), ['action' => 'index']) ?></li>
+        <li><?= $this->Html->link(__('List Users'), ['controller' => 'Users', 'action' => 'index']) ?></li>
+        <li><?= $this->Html->link(__('New User'), ['controller' => 'Users', 'action' => 'add']) ?></li>
+    </ul>
+</nav>
+<div class="cancellingAccountHistories form large-9 medium-8 columns content">
+    <?= $this->Form->create($cancellingAccountHistory) ?>
+    <fieldset>
+        <legend><?= __('Add Cancelling Account History') ?></legend>
+        <?php
+            echo $this->Form->control('user_id', ['options' => $users]);
+            echo $this->Form->control('cancelling_category_id');
+            echo $this->Form->control('cancelled');
+        ?>
+    </fieldset>
+    <?= $this->Form->button(__('Submit')) ?>
+    <?= $this->Form->end() ?>
+</div>

--- a/html/mycakeapp/src/Template/CancellingAccountHistories/edit.ctp
+++ b/html/mycakeapp/src/Template/CancellingAccountHistories/edit.ctp
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var \App\Model\Entity\CancellingAccountHistory $cancellingAccountHistory
+ */
+?>
+<nav class="large-3 medium-4 columns" id="actions-sidebar">
+    <ul class="side-nav">
+        <li class="heading"><?= __('Actions') ?></li>
+        <li><?= $this->Form->postLink(
+                __('Delete'),
+                ['action' => 'delete', $cancellingAccountHistory->id],
+                ['confirm' => __('Are you sure you want to delete # {0}?', $cancellingAccountHistory->id)]
+            )
+        ?></li>
+        <li><?= $this->Html->link(__('List Cancelling Account Histories'), ['action' => 'index']) ?></li>
+        <li><?= $this->Html->link(__('List Users'), ['controller' => 'Users', 'action' => 'index']) ?></li>
+        <li><?= $this->Html->link(__('New User'), ['controller' => 'Users', 'action' => 'add']) ?></li>
+    </ul>
+</nav>
+<div class="cancellingAccountHistories form large-9 medium-8 columns content">
+    <?= $this->Form->create($cancellingAccountHistory) ?>
+    <fieldset>
+        <legend><?= __('Edit Cancelling Account History') ?></legend>
+        <?php
+            echo $this->Form->control('user_id', ['options' => $users]);
+            echo $this->Form->control('cancelling_category_id');
+            echo $this->Form->control('cancelled');
+        ?>
+    </fieldset>
+    <?= $this->Form->button(__('Submit')) ?>
+    <?= $this->Form->end() ?>
+</div>

--- a/html/mycakeapp/src/Template/CancellingAccountHistories/index.ctp
+++ b/html/mycakeapp/src/Template/CancellingAccountHistories/index.ctp
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var \App\Model\Entity\CancellingAccountHistory[]|\Cake\Collection\CollectionInterface $cancellingAccountHistories
+ */
+?>
+<nav class="large-3 medium-4 columns" id="actions-sidebar">
+    <ul class="side-nav">
+        <li class="heading"><?= __('Actions') ?></li>
+        <li><?= $this->Html->link(__('New Cancelling Account History'), ['action' => 'add']) ?></li>
+        <li><?= $this->Html->link(__('List Users'), ['controller' => 'Users', 'action' => 'index']) ?></li>
+        <li><?= $this->Html->link(__('New User'), ['controller' => 'Users', 'action' => 'add']) ?></li>
+    </ul>
+</nav>
+<div class="cancellingAccountHistories index large-9 medium-8 columns content">
+    <h3><?= __('Cancelling Account Histories') ?></h3>
+    <table cellpadding="0" cellspacing="0">
+        <thead>
+            <tr>
+                <th scope="col"><?= $this->Paginator->sort('id') ?></th>
+                <th scope="col"><?= $this->Paginator->sort('user_id') ?></th>
+                <th scope="col"><?= $this->Paginator->sort('cancelling_category_id') ?></th>
+                <th scope="col"><?= $this->Paginator->sort('cancelled') ?></th>
+                <th scope="col" class="actions"><?= __('Actions') ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($cancellingAccountHistories as $cancellingAccountHistory): ?>
+            <tr>
+                <td><?= $this->Number->format($cancellingAccountHistory->id) ?></td>
+                <td><?= $cancellingAccountHistory->has('user') ? $this->Html->link($cancellingAccountHistory->user->id, ['controller' => 'Users', 'action' => 'view', $cancellingAccountHistory->user->id]) : '' ?></td>
+                <td><?= $this->Number->format($cancellingAccountHistory->cancelling_category_id) ?></td>
+                <td><?= h($cancellingAccountHistory->cancelled) ?></td>
+                <td class="actions">
+                    <?= $this->Html->link(__('View'), ['action' => 'view', $cancellingAccountHistory->id]) ?>
+                    <?= $this->Html->link(__('Edit'), ['action' => 'edit', $cancellingAccountHistory->id]) ?>
+                    <?= $this->Form->postLink(__('Delete'), ['action' => 'delete', $cancellingAccountHistory->id], ['confirm' => __('Are you sure you want to delete # {0}?', $cancellingAccountHistory->id)]) ?>
+                </td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <div class="paginator">
+        <ul class="pagination">
+            <?= $this->Paginator->first('<< ' . __('first')) ?>
+            <?= $this->Paginator->prev('< ' . __('previous')) ?>
+            <?= $this->Paginator->numbers() ?>
+            <?= $this->Paginator->next(__('next') . ' >') ?>
+            <?= $this->Paginator->last(__('last') . ' >>') ?>
+        </ul>
+        <p><?= $this->Paginator->counter(['format' => __('Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')]) ?></p>
+    </div>
+</div>

--- a/html/mycakeapp/src/Template/CancellingAccountHistories/view.ctp
+++ b/html/mycakeapp/src/Template/CancellingAccountHistories/view.ctp
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ * @var \App\Model\Entity\CancellingAccountHistory $cancellingAccountHistory
+ */
+?>
+<nav class="large-3 medium-4 columns" id="actions-sidebar">
+    <ul class="side-nav">
+        <li class="heading"><?= __('Actions') ?></li>
+        <li><?= $this->Html->link(__('Edit Cancelling Account History'), ['action' => 'edit', $cancellingAccountHistory->id]) ?> </li>
+        <li><?= $this->Form->postLink(__('Delete Cancelling Account History'), ['action' => 'delete', $cancellingAccountHistory->id], ['confirm' => __('Are you sure you want to delete # {0}?', $cancellingAccountHistory->id)]) ?> </li>
+        <li><?= $this->Html->link(__('List Cancelling Account Histories'), ['action' => 'index']) ?> </li>
+        <li><?= $this->Html->link(__('New Cancelling Account History'), ['action' => 'add']) ?> </li>
+        <li><?= $this->Html->link(__('List Users'), ['controller' => 'Users', 'action' => 'index']) ?> </li>
+        <li><?= $this->Html->link(__('New User'), ['controller' => 'Users', 'action' => 'add']) ?> </li>
+    </ul>
+</nav>
+<div class="cancellingAccountHistories view large-9 medium-8 columns content">
+    <h3><?= h($cancellingAccountHistory->id) ?></h3>
+    <table class="vertical-table">
+        <tr>
+            <th scope="row"><?= __('User') ?></th>
+            <td><?= $cancellingAccountHistory->has('user') ? $this->Html->link($cancellingAccountHistory->user->id, ['controller' => 'Users', 'action' => 'view', $cancellingAccountHistory->user->id]) : '' ?></td>
+        </tr>
+        <tr>
+            <th scope="row"><?= __('Id') ?></th>
+            <td><?= $this->Number->format($cancellingAccountHistory->id) ?></td>
+        </tr>
+        <tr>
+            <th scope="row"><?= __('Cancelling Category Id') ?></th>
+            <td><?= $this->Number->format($cancellingAccountHistory->cancelling_category_id) ?></td>
+        </tr>
+        <tr>
+            <th scope="row"><?= __('Cancelled') ?></th>
+            <td><?= h($cancellingAccountHistory->cancelled) ?></td>
+        </tr>
+    </table>
+</div>

--- a/html/mycakeapp/tests/Fixture/CancellingAccountHistoriesFixture.php
+++ b/html/mycakeapp/tests/Fixture/CancellingAccountHistoriesFixture.php
@@ -1,0 +1,48 @@
+<?php
+namespace App\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * CancellingAccountHistoriesFixture
+ */
+class CancellingAccountHistoriesFixture extends TestFixture
+{
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    // @codingStandardsIgnoreStart
+    public $fields = [
+        'id' => ['type' => 'integer', 'length' => null, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
+        'user_id' => ['type' => 'integer', 'length' => null, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        'cancelling_category_id' => ['type' => 'integer', 'length' => null, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        'cancelled' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8_general_ci'
+        ],
+    ];
+    // @codingStandardsIgnoreEnd
+    /**
+     * Init method
+     *
+     * @return void
+     */
+    public function init()
+    {
+        $this->records = [
+            [
+                'id' => 1,
+                'user_id' => 1,
+                'cancelling_category_id' => 1,
+                'cancelled' => '2020-12-01 16:15:42',
+            ],
+        ];
+        parent::init();
+    }
+}

--- a/html/mycakeapp/tests/TestCase/Controller/CancellingAccountHistoriesControllerTest.php
+++ b/html/mycakeapp/tests/TestCase/Controller/CancellingAccountHistoriesControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+namespace App\Test\TestCase\Controller;
+
+use App\Controller\CancellingAccountHistoriesController;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * App\Controller\CancellingAccountHistoriesController Test Case
+ *
+ * @uses \App\Controller\CancellingAccountHistoriesController
+ */
+class CancellingAccountHistoriesControllerTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'app.CancellingAccountHistories',
+        'app.Users',
+        'app.CancellingCategories',
+    ];
+
+    /**
+     * Test index method
+     *
+     * @return void
+     */
+    public function testIndex()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test view method
+     *
+     * @return void
+     */
+    public function testView()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test add method
+     *
+     * @return void
+     */
+    public function testAdd()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test edit method
+     *
+     * @return void
+     */
+    public function testEdit()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test delete method
+     *
+     * @return void
+     */
+    public function testDelete()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+}

--- a/html/mycakeapp/tests/TestCase/Controller/CancellingAccountHistoriesControllerTest.php
+++ b/html/mycakeapp/tests/TestCase/Controller/CancellingAccountHistoriesControllerTest.php
@@ -23,7 +23,7 @@ class CancellingAccountHistoriesControllerTest extends TestCase
     public $fixtures = [
         'app.CancellingAccountHistories',
         'app.Users',
-        'app.cancelling_account_categories',
+        'app.CancelleingAcountCategories',
     ];
 
     /**

--- a/html/mycakeapp/tests/TestCase/Controller/CancellingAccountHistoriesControllerTest.php
+++ b/html/mycakeapp/tests/TestCase/Controller/CancellingAccountHistoriesControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Test\TestCase\Controller;
 
 use App\Controller\CancellingAccountHistoriesController;
@@ -22,7 +23,7 @@ class CancellingAccountHistoriesControllerTest extends TestCase
     public $fixtures = [
         'app.CancellingAccountHistories',
         'app.Users',
-        'app.CancellingCategories',
+        'app.cancelling_account_categories',
     ];
 
     /**

--- a/html/mycakeapp/tests/TestCase/Model/Table/CancellingAccountHistoriesTableTest.php
+++ b/html/mycakeapp/tests/TestCase/Model/Table/CancellingAccountHistoriesTableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Test\TestCase\Model\Table;
 
 use App\Model\Table\CancellingAccountHistoriesTable;
@@ -25,7 +26,7 @@ class CancellingAccountHistoriesTableTest extends TestCase
     public $fixtures = [
         'app.CancellingAccountHistories',
         'app.Users',
-        'app.CancellingCategories',
+        'app.cancelling_account_categories',
     ];
 
     /**

--- a/html/mycakeapp/tests/TestCase/Model/Table/CancellingAccountHistoriesTableTest.php
+++ b/html/mycakeapp/tests/TestCase/Model/Table/CancellingAccountHistoriesTableTest.php
@@ -26,7 +26,7 @@ class CancellingAccountHistoriesTableTest extends TestCase
     public $fixtures = [
         'app.CancellingAccountHistories',
         'app.Users',
-        'app.cancelling_account_categories',
+        'app.CancelleingAcountCategories',
     ];
 
     /**

--- a/html/mycakeapp/tests/TestCase/Model/Table/CancellingAccountHistoriesTableTest.php
+++ b/html/mycakeapp/tests/TestCase/Model/Table/CancellingAccountHistoriesTableTest.php
@@ -1,0 +1,84 @@
+<?php
+namespace App\Test\TestCase\Model\Table;
+
+use App\Model\Table\CancellingAccountHistoriesTable;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+/**
+ * App\Model\Table\CancellingAccountHistoriesTable Test Case
+ */
+class CancellingAccountHistoriesTableTest extends TestCase
+{
+    /**
+     * Test subject
+     *
+     * @var \App\Model\Table\CancellingAccountHistoriesTable
+     */
+    public $CancellingAccountHistories;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    public $fixtures = [
+        'app.CancellingAccountHistories',
+        'app.Users',
+        'app.CancellingCategories',
+    ];
+
+    /**
+     * setUp method
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $config = TableRegistry::getTableLocator()->exists('CancellingAccountHistories') ? [] : ['className' => CancellingAccountHistoriesTable::class];
+        $this->CancellingAccountHistories = TableRegistry::getTableLocator()->get('CancellingAccountHistories', $config);
+    }
+
+    /**
+     * tearDown method
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->CancellingAccountHistories);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test initialize method
+     *
+     * @return void
+     */
+    public function testInitialize()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test validationDefault method
+     *
+     * @return void
+     */
+    public function testValidationDefault()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+
+    /**
+     * Test buildRules method
+     *
+     * @return void
+     */
+    public function testBuildRules()
+    {
+        $this->markTestIncomplete('Not implemented yet.');
+    }
+}


### PR DESCRIPTION
## 今回実装した機能、または改善した問題点
cancelling_account_historiesのmigrationファイル作成、mvc
cancelling_account_categoriesとのアソシエーションの修正
#### 実装の概要
- migrationファイルの作成
- アソシエーションの修正

#### レビューして欲しい内容
- migrationした際の外部キーなどは適切か。
- アソシエーションは正しいか。

#### 不安に思っている点
-時間かかってすみません。外部キーのところでかなり手こずってました。
cancelling_account_categoriesとしたいところがCancellingCategoriesになっていて
一つ一つ確認しながらやりましたがもしかしたら漏れがあるかもしれません。
変数名で当たっているところはそのままにしてます。


#### 保留にしている点
-

#### 目標スプリント数、結果スプリント数
- 目標：0.5
- 結果：1

#### 関連するプルリクあればそのリンク
