### PR TITLE
Feature/credit validation update

### DIFF
--- a/html/mycakeapp/src/Controller/BookingsController.php
+++ b/html/mycakeapp/src/Controller/BookingsController.php
@@ -31,6 +31,26 @@ class BookingsController extends MovieAuthBaseController
 
         $this->set('authuser', $this->Auth->user());
     }
+
+    /**
+     * 一般ユーザーがアクセスできるのをaddSeatアクションのみに指定
+     * 予約したユーザーのみ、その予約確認画面にアクセス・キャンセル可能ユーザーに指定
+     */
+    public function isAuthorized($user)
+    {
+        // 登録ユーザー全員が予約可
+        if ($this->request->getParam('action') === 'addSeat') {
+            return true;
+        }
+        // 予約の所有者は確認画面にアクセス・キャンセル可能
+        if (in_array($this->request->getParam('action'), ['seatConfirmation', 'seatCancel'])) {
+            $bookingId = (int)$this->request->getParam('pass.0');
+            if ($this->Bookings->isOwnedBy($bookingId, $user['id'])) {
+                return true;
+            }
+        }
+        return parent::isAuthorized($user);
+    }
     /**
      * Index method
      *

--- a/html/mycakeapp/src/Controller/CreditCardsController.php
+++ b/html/mycakeapp/src/Controller/CreditCardsController.php
@@ -64,16 +64,18 @@ class CreditCardsController extends MovieAuthBaseController
                  * 処理の流れ（備考）エンティティ関連の値を操作するメソッドは全てCreditCard.phpに記載
                  * 1. ユーザーIDをセット(setUserIdメソッド)
                  * 2. is_deletedをセット(setIsDeletedメソッド)
-                 * 3. 暗号化 (encryptメソッド)
+                 * 3. 名前を全て大文字にする
+                 * 4. 暗号化 (encryptメソッド)
                  */
 
                 // 1. user_idの値をセット
                 $user_id = $this->Auth->user('id');
                 $creditCard = $creditCard->setUserId($user_id);
-
                 // 2. is_deletedの値をセット
                 $creditCard = $creditCard->setIsDeleted();
-                // 3. 暗号化
+                // 3. 名義人文字列を全て大文字化
+                $creditCard->holder_name = strtoupper($creditCard->holder_name);
+                // 4. 暗号化
                 $creditCard = $creditCard->encrypt();
             }
             if ($this->CreditCards->save($creditCard)) {

--- a/html/mycakeapp/src/Controller/MovieAuthBaseController.php
+++ b/html/mycakeapp/src/Controller/MovieAuthBaseController.php
@@ -95,7 +95,7 @@ class MovieAuthBaseController extends AppController
     }
     // 一般ユーザーは'Bookings','MoviesInfo', 'CreditCards', 'PaymentHistories' のControllerのみtrue、他はfalse,他必要なコントローラは順次追加する
     else {
-      if ($this->name === 'Bookings' || $this->name === 'MoviesInfo' || $this->name === 'CreditCards' || $this->name === 'PaymentHistories') {
+      if ($this->name === 'MoviesInfo' || $this->name === 'CreditCards' || $this->name === 'PaymentHistories') {
         return true;
       } else {
         return false;

--- a/html/mycakeapp/src/Model/Table/BookingsTable.php
+++ b/html/mycakeapp/src/Model/Table/BookingsTable.php
@@ -171,7 +171,7 @@ class BookingsTable extends Table
         return $bookings;
     }
 
-     /**
+    /**
      * ユーザー退会時の予約取り消しメソッド
      * 1. そのユーザーの
      * 2. まだキャンセルされてない
@@ -186,5 +186,13 @@ class BookingsTable extends Table
             $booking = $booking->setIsCancelled();
         }
         return $bookings;
+    }
+
+    /**
+     * 予約したユーザーを検索
+     */
+    public function isOwnedBy($bookingId, $userId)
+    {
+        return $this->exists(['id' => $bookingId, 'user_id' => $userId]);
     }
 }

--- a/html/mycakeapp/src/Model/Table/CreditCardsTable.php
+++ b/html/mycakeapp/src/Model/Table/CreditCardsTable.php
@@ -187,7 +187,7 @@ class CreditCardsTable extends Table
      * @return array そのuser_idで登録されたクレジットカード情報の一覧（復号化した後、カード番号に関しては下4桁のみ表示）
      * 処理流れ（復号化と、有効期限比較）
      * 1. ユーザーIDが一致&削除されていないクレカ情報を取得
-     * 2. 今月末の日付情報を取得('Y-m-d')
+     * 2. 今月末の日付情報を取得('Y-m-d') 参考URL(の例3)：https://www.php.net/manual/ja/function.mktime
      * 3. 復号化
      * 4. 復号化された有効期限を、'Y-m-d'のdate型に変換
      * 5. 2.で取得した今月末の日付情報と4.を比較し、今月末の日付情報の方が新しいクレカ情報は配列から削除しforeachを続ける

--- a/html/mycakeapp/src/Model/Table/CreditCardsTable.php
+++ b/html/mycakeapp/src/Model/Table/CreditCardsTable.php
@@ -178,6 +178,7 @@ class CreditCardsTable extends Table
     public function buildRules(RulesChecker $rules)
     {
         $rules->add($rules->existsIn(['user_id'], 'Users'));
+        $rules->add($rules->isUnique(['card_number'], 'すでに登録されているカードです。'));
 
         return $rules;
     }

--- a/html/mycakeapp/src/Model/Table/CreditCardsTable.php
+++ b/html/mycakeapp/src/Model/Table/CreditCardsTable.php
@@ -80,8 +80,7 @@ class CreditCardsTable extends Table
             // チェックデジットの追加 参考URL =>  https://www.gizmodo.jp/2011/01/post_8367.html
             // テスト用カード番号 => https://pay.jp/docs/testcard
             // アルゴリズムコード参考 => https://en.wikipedia.org/wiki/Luhn_algorithm
-            //->add('card_number', 'why', ['rule' => function ($value, $context) {
-            ->add('card_number', 'why', ['rule' => function ($value, $context) {
+            ->add('card_number', 'custom', ['rule' => function ($value, $context) {
                 $length = strlen($value);
                 $sum = (int) $value[$length - 1];
                 $parity = $length % 2;

--- a/html/mycakeapp/src/Model/Table/CreditCardsTable.php
+++ b/html/mycakeapp/src/Model/Table/CreditCardsTable.php
@@ -74,11 +74,13 @@ class CreditCardsTable extends Table
                 if (preg_match("/\A[4,5][0-9]{15}\z/", $value)) {
                     return true;
                 }
-            }, 'message' => '不正なカード番号です。'])
+                return '不正なカード番号です。';
+            }])
             // [4]or[5]から始まる番号でも、チェックデジットによって確認が取れなければfalseを返す
             // チェックデジットの追加 参考URL =>  https://www.gizmodo.jp/2011/01/post_8367.html
             // テスト用カード番号 => https://pay.jp/docs/testcard
             // アルゴリズムコード参考 => https://en.wikipedia.org/wiki/Luhn_algorithm
+            //->add('card_number', 'why', ['rule' => function ($value, $context) {
             ->add('card_number', 'why', ['rule' => function ($value, $context) {
                 $length = strlen($value);
                 $sum = (int) $value[$length - 1];
@@ -96,7 +98,8 @@ class CreditCardsTable extends Table
                 if ($sum % 10 === 0) {
                     return true;
                 }
-            }, 'message' => '不正なカード番号です。']);
+                return '不正なカード番号です。';
+            }]);
 
         $validator
             ->scalar('holder_name')

--- a/html/mycakeapp/src/Model/Table/CreditCardsTable.php
+++ b/html/mycakeapp/src/Model/Table/CreditCardsTable.php
@@ -227,8 +227,15 @@ class CreditCardsTable extends Table
             ->select(['id', 'card_number', 'holder_name', 'expiration_date'])
             ->where(['user_id' => $user_id, 'is_deleted' => 0])
             ->toList();
-        foreach ($creditcards as $creditcard) {
+        $endOfMonth = date('Y-m-d', mktime(0, 0, 0, date('m') + 1, 0, date('Y')));
+        foreach ($creditcards as $key => $creditcard) {
             $creditcard = $creditcard->decrypt();
+            $month = substr($creditcard->expiration_date, 0, 2);
+            $year = sprintf('20%s', substr($creditcard->expiration_date, 2, 2));
+            $expiration = date('Y-m-d', mktime(0, 0, 0, (int)$month + 1, 0, $year));
+            if ($expiration < $endOfMonth) {
+                unset($creditcards[$key]);
+            }
             $creditcard->card_number = '******' . substr($creditcard->card_number, -4);
         }
 


### PR DESCRIPTION
## 今回実装した機能、または改善した問題点

#### 実装の概要
- 有効期限が過ぎたクレジットカードは編集画面に出てこない・決済時選択画面にでてこないようにした。
- バリデーションエラーでデフォルト値が出てくるのを修正。
- Bookingsコントローラの認可(addSeatのみどのユーザーもアクセス可、予約確認とキャンセル画面のみそのユーザーに限ってアクセス可能)
 - カード名義の入力欄で、小文字で入力されても大文字に変換して保存するようにした。

#### レビューして欲しい内容
- 上記

#### 不安に思っている点
- `card_number`のバリデーションエラーで、指定したメッセージではなくデフォルト値が表示されるバグはどうして起こるのか結局理由がわかりませんでした🙄
他の`holder_name`等と同じように書いているはずですが、`card_number`だけ期待した表示がされません🙄
なので`card_number`に関しては、https://book.cakephp.org/3/ja/orm/validation.html#id7 の2つ目の例を参考に指定したバリデーションエラーの表示をさせました。

#### 保留にしている点
- 特になし

#### 目標スプリント数、結果スプリント数
- 目標：構想外
- 結果：

#### 関連するプルリクあればそのリンク
